### PR TITLE
Feature/create cmake build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Build folder
+**/build
+
+# Temporary user files
+**/CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(memscan VERSION 0.1.0 LANGUAGES CXX)
 
 ## build conditions:
 
-if(NOT MSVC OR NOT ${CMAKE_SIZEOF_VOID_P} STREQUAL 4)
-  message(FATAL_ERROR "Error: memscan only supports Windows x64 right now!")
+if(NOT MSVC)
+  message(FATAL_ERROR "Error: memscan only supports Windows right now!")
 endif()
 
 ## build settings:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 project(memscan VERSION 0.1.0 LANGUAGES CXX)
 
+## build conditions:
+
+if(NOT MSVC)
+  message(FATAL_ERROR "Error: memscan only supports Windows right now!")
+endif()
+
 ## build settings:
 
 set(CMAKE_CXX_STANDARD 11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+project(memscan VERSION 0.1.0 LANGUAGES CXX)
+
+## build settings:
+
+set(CMAKE_CXX_STANDARD 11)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the build type" FORCE)
+endif()
+
+set(CMAKE_CXX_FLAGS_RELEASE -O2)
+
+## files:
+
+set(source_files
+  Memscan.cpp
+  main.cpp
+  utils.cpp)
+
+set(header_files
+  Memscan.h
+  utils.h)
+
+## executable:
+
+add_executable(${PROJECT_NAME}
+  ${source_files}
+  ${header_files})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(memscan VERSION 0.1.0 LANGUAGES CXX)
 
 ## build conditions:
 
-if(NOT MSVC)
-  message(FATAL_ERROR "Error: memscan only supports Windows right now!")
+if(NOT MSVC OR NOT ${CMAKE_SIZEOF_VOID_P} STREQUAL 4)
+  message(FATAL_ERROR "Error: memscan only supports Windows x64 right now!")
 endif()
 
 ## build settings:

--- a/Memscan.cpp
+++ b/Memscan.cpp
@@ -56,7 +56,7 @@ Memscan::Memscan(string pin, PROCESS_MODE process_mode) {
 		wchar_t* temp_process_name = new wchar_t[temp_size];
 		// loop gets process name from process handle
 		while (true) {
-			if (0 == GetProcessImageFileName(process_handle, temp_process_name, temp_size)) {
+			if (0 == GetProcessImageFileNameW(process_handle, temp_process_name, temp_size)) {
 				cerr << "Error: GetProcessImageFileName() failed in " << basename(__FILE__) << ":" << __LINE__ << ". Last error: " << GetLastError() << "." << endl;
 				exit(1);
 			} else if (wcslen(temp_process_name) == (temp_size-1)) {

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ You can also specify the combination of memory units you want to scan for (e.g.,
 
 Would scan the process for dwords and quadwords.
 
+### Building
+
+Being [Cmake](https://cmake.org/)-based, configure the project (preferably *out-of-source*) and run the build. Here is an example:
+
+```shh
+memscan$ mkdir build
+memscan$ cd build
+memscan/build$ cmake ..
+memscan/build$ cmake --build .
+```
+
 ### License
 memscan is distributed under the GNU General Public License v3.0 (GPLv3).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+os: Visual Studio 2015
+
+platform:
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+init:
+  - cmd: cmake --version
+  - cmd: msbuild /version
+
+build_script:
+  - cmd: md build
+  - cmd: cd build
+  - cmd: cmake -G "Visual Studio 14 2015 Win64" ..
+  - cmd: cmake --build . --config %configuration%

--- a/utils.cpp
+++ b/utils.cpp
@@ -200,7 +200,7 @@ HMODULE get_base_address(HANDLE process_handle, wstring path) {
 	wchar_t* module_path = new wchar_t[path.length()+1];
 	// find module of specified path
 	for (int i = 0; i < (needed/sizeof(HMODULE)); i++) {
-		GetModuleFileNameEx(process_handle, hmarr[i], module_path, (DWORD) path.length());
+		GetModuleFileNameExW(process_handle, hmarr[i], module_path, (DWORD) path.length());
 		if (to_upper(basename(path)) == to_upper(basename(module_path))) {
 			rtn = hmarr[i];
 			break;


### PR DESCRIPTION
This PR adds a CMake build script for **memscan**. With the script things get a bit easier to configure and build the project. Here is a few extras:

- the only actual source modifications were the calls to **GetModuleFileNameExW** and **GetProcessImageFileNameW** due to conversion from `wchar_t*` to `LPCSTR`;

- added a small build guide on the README file;

- for my fork I created a project in [AppVeyor](https://ci.appveyor.com/project/benvenutti/memscan) to have a continuous integration build running on each push. That's what the `appveyor.yml` script is for. You can easily create one too, it's free! Since the script is already working, you just have to actually create a AppVeyor account and activate **memscan**. After the first push, you will get a build. Later on I can add a badge on the README file with the build status.